### PR TITLE
pack.cmd  Fix timestamp

### DIFF
--- a/pygin/pack.cmd
+++ b/pygin/pack.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-for /f "tokens=1-4 delims=. " %%a in ('date /t') do (set timestamp=%%c%%b%%a)
+for /f "tokens=2-4 delims=./ " %%a in ('date /t') do (set timestamp=%%c%%b%%a)
 for /f %%i in ('git rev-parse --short HEAD') do set hash=%%i
 
 pushd artefacts\product


### PR DESCRIPTION
Without fix produces pygin_07/09/2017Sun_035c048.7z on AppVeyor.
`date /t` returns Sun 07/09/2017

https://ci.appveyor.com/project/techtonik/evil-programmers/build/1.0.27/job/o5fmeo71e64lj5to#L51